### PR TITLE
Hotfix to correctly calculate future weekcode for bkm

### DIFF
--- a/src/main/java/dk/dbc/weekresolver/service/WeekResolver.java
+++ b/src/main/java/dk/dbc/weekresolver/service/WeekResolver.java
@@ -501,8 +501,8 @@ public class WeekResolver {
         // Locate Easter sunday for current year
         Optional<LocalDate> optionalSunday = EASTER_SUNDAYS.stream().filter(x -> x.getYear() == dateOfSunday.getYear()).findFirst();
         if(!optionalSunday.isPresent()) {
-            LOGGER.warn("Request for date in the far-off past or future, date can not be checked for Easter");
-            throw new BadRequestException("Date is too far-off into the past");
+            LOGGER.warn("Date {} is too far-off into the past", dateOfSunday.toString());
+            throw new BadRequestException(String.format("Date %s is too far-off into the past", dateOfSunday.toString()));
         }
         LocalDate easterSunday = optionalSunday.get();
         LOGGER.info("Easter sunday for {} is {}", dateOfSunday.getYear(), easterSunday);

--- a/src/main/java/dk/dbc/weekresolver/service/WeekResolverService.java
+++ b/src/main/java/dk/dbc/weekresolver/service/WeekResolverService.java
@@ -26,8 +26,6 @@ public class WeekResolverService {
     @Inject
     @ConfigProperty(name = "TZ")
     String timeZone;
-    //@EJB
-    //WeekResolverBean weekResolver;
 
     /**
      * Endpoint for getting the week code based on catalogueCode and todays date

--- a/src/test/java/dk/dbc/weekresolver/service/WeekResolverTest.java
+++ b/src/test/java/dk/dbc/weekresolver/service/WeekResolverTest.java
@@ -226,7 +226,7 @@ class WeekResolverTest {
     void TestYearEnd() {
         WeekResolver b = new WeekResolver().withCatalogueCode("BKM");
         assertThat(b.withDate("2019-12-03").build().getWeekCode(), is("BKM201951"));
-        assertThat(b.withDate("2019-12-10").build().getWeekCode(), is("BKM202001"));
+        assertThat(b.withDate("2019-12-10").build().getWeekCode(), is("BKM202002"));
     }
 
     @Test
@@ -298,7 +298,7 @@ class WeekResolverTest {
         assertThat(b.withCatalogueCode("PLN").withDate("2020-04-30").build().getWeekCode(), is("PLN202005"));
 
         // GBF is a bit weird
-        assertThat(b.withCatalogueCode("GBF").withDate("2019-11-26").build().getWeekCode(), is("GBF202001"));
+        assertThat(b.withCatalogueCode("GBF").withDate("2019-11-26").build().getWeekCode(), is("GBF202002"));
     }
 
     @Test
@@ -344,5 +344,13 @@ class WeekResolverTest {
         // "Grundlovsdag. Torsdag d. 04.06.20 afsluttes DBF+BKM202026. Torsdag morgen skal koden være 202027"
         assertThat(b.withCatalogueCode("DBF").withDate("2020-06-04").build().getWeekCode(), is("DBF202026"));
         assertThat(b.withCatalogueCode("BKM").withDate("2020-06-04").build().getWeekCode(), is("BKM202026"));
+    }
+
+    @Test
+    void TestFirstWeekOfYear() {
+        WeekResolver b = new WeekResolver().withCatalogueCode("BKM");
+        assertThat(b.withDate("2022-12-01").build().getWeekCode(), is("BKM202250"));
+        assertThat(b.withDate("2022-12-05").build().getWeekCode(), is("BKM202302"));
+        assertThat(b.withDate("2022-12-15").build().getWeekCode(), is("BKM202302"));
     }
 }


### PR DESCRIPTION
taking into account that, as an unwritten rule, we do not want production codes in the first week of the year for codes honoring christmas closing days

Beware: There is some typo fixes and refactoring to simplify a redundant block. Only the weekcode = 1 check and associated test is really new